### PR TITLE
Change smeltingType to "fire" instead of "bake" 

### DIFF
--- a/mods/zeekea/assets/zeekea/blocktypes/clay/mold/bellhead_mold.json
+++ b/mods/zeekea/assets/zeekea/blocktypes/clay/mold/bellhead_mold.json
@@ -31,7 +31,7 @@
 			meltingPoint: 650,
 			meltingDuration: 45,
 			smeltedRatio: 1,
-			smeltingType: "bake",
+			smeltingType: "fire",
 			smeltedStack: { type: "block", code: "toolmold-burned-{tooltype}" },
 			requiresContainer: false
 		}

--- a/mods/zeekea/assets/zeekea/blocktypes/clay/mold/icepickhead_mold.json
+++ b/mods/zeekea/assets/zeekea/blocktypes/clay/mold/icepickhead_mold.json
@@ -33,7 +33,7 @@
 			meltingPoint: 650,
 			meltingDuration: 45,
 			smeltedRatio: 1,
-			smeltingType: "bake",
+			smeltingType: "fire",
 			smeltedStack: { type: "block", code: "toolmold-burned-{tooltype}" },
 			requiresContainer: false
 		}


### PR DESCRIPTION
Bellhead mold and icepick mold can't be fired at the moment because the smeltingType is "bake"; changing it to "fire" would allow this. 